### PR TITLE
Fix vcvarsall.bat path detection

### DIFF
--- a/impl/msvc.py
+++ b/impl/msvc.py
@@ -127,7 +127,17 @@ class ProjectGenerator:
 
     def _get_visual_studio_env(self, version, platform):
         vspath = self._get_visual_studio_path(version)
-        env = self._load_env_from_bat([vspath + "\\VC\\Auxiliary\\Build\\vcvarsall.bat", platform])
+
+        batpath = os.path.join(vspath, 'VC', 'vcvarsall.bat')
+
+        if not os.path.exists(batpath):
+            batpath = os.path.join(vspath, 'VC', 'Auxiliary', 'Build', 'vcvarsall.bat')
+
+        if not os.path.exists(batpath):
+            raise Exception('%s doesn\'t exist. Does your VS have C++ support?' % batpath)
+
+        env = self._load_env_from_bat([batpath, platform])
+
         env = self._extract_important_env(env)
         return env
 


### PR DESCRIPTION
This small change fixes project generation with MS VC 2015 - your original script was looking for vcvarsall.bat at MS VC 2017's location. This patch tries to locate script at MS VC 2015 location, and if it fails - at MS VC 2017.